### PR TITLE
Make sure tag builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,12 @@ script:
   - make travis-test
 
 deploy:
-  - provider: script
-    script: make travis-deploy
-    cleanup: false
-    on:
-      condition: $TRAVIS_BRANCH = main || ! -z $TRAVIS_TAG
+  provider: script
+  script: make travis-deploy
+  cleanup: false
+  on:
+    all_branches: true
+    condition: $TRAVIS_BRANCH = main || ! -z $TRAVIS_TAG
 
 cache:
   directories:


### PR DESCRIPTION
Follow up from #3, tag [still does not build](https://travis-ci.com/github/IBM/detect-secrets-stream/jobs/506228538)... hope this is the final try. Added `all_branches: true` and relying on `condition` to filter off invalid cases.