### PR TITLE
Dev instance docs

### DIFF
--- a/kustomize_envs/dev/README.md
+++ b/kustomize_envs/dev/README.md
@@ -7,11 +7,11 @@ This doc describes how to use `skaffold` to run a detect-secrets-stream instance
 ### provision ahead of time (already done)
 
 - github-app: [detect-secrets-admin-tool-test](https://github.ibm.com/github-apps/detect-secrets-admin-tool-test)
-  - `kustomize_envs/dev/secret/app.key` stores the private key for this test Github App
-  - `APP_ID` in `kustomize_envs/dev/secret/env.txt` stores the Github App ID
+  - `kustomize_envs/dev/secret_manual/app.key` stores the private key for this test Github App
+  - `APP_ID` in `kustomize_envs/dev/secret_manual/env.txt` stores the Github App ID
 - a kafka queue named `diff-scan`
   - You can request a free kafka instance in your own IBM Cloud account. Service link: https://cloud.ibm.com/catalog/services/event-streams. Once created, generate a queue named `diff-scan` in the kafka instance. **TODO** parameterize queue name
-  - The one stored `kustomize_envs/dev/secret/kafka.conf` is under @xianjun's account. Multiple people sharing the same queue can cause confusion when ingesting token.
+  - The one stored `kustomize_envs/dev/secret_manual/kafka.conf` is under @xianjun's account. Multiple people sharing the same queue can cause confusion when ingesting token.
 
 ### ondemand provision
 

--- a/kustomize_envs/dev/README.md
+++ b/kustomize_envs/dev/README.md
@@ -12,6 +12,7 @@ This doc describes how to use `skaffold` to run a detect-secrets-stream instance
   - `APP_ID` in `kustomize_envs/dev/secret_manual/env.txt` stores the Github App ID
 - a kafka queue named `diff-scan`
   - You can request a free kafka instance in your own IBM Cloud account. Service link: https://cloud.ibm.com/catalog/services/event-streams. Once created, generate a queue named `diff-scan` in the kafka instance. **TODO** parameterize queue name
+
 ### ondemand provision
 
 The resource below would be automatically provisioned when you run skaffold
@@ -77,6 +78,7 @@ kubectl exec -n dev -it $(kubectl get pods -n dev -l app=postgres -o jsonpath="{
 ```
 
 Allows running manual SQL commands against your postgresql database
+
 ```
 # Run inside of the container
 # connect to dss database and get all rows from "token" table

--- a/kustomize_envs/dev/README.md
+++ b/kustomize_envs/dev/README.md
@@ -35,6 +35,8 @@ kubectl config current-context # make sure you are on the kind cluster
 kubectl create ns dev
 
 # generate local secrets
+# you can follow the guide in ../README#local-dev-secrets to set up your secrets
+# re-running the gen-secret script will not overwrite non-empty files
 kustomize_envs/dev/gen-secret.sh
 
 # build image and deploy to dev cluster. "skaffold dev" would tail on log after image been deployed. In the meanwhile, you can use tools like k9s to monitor the status in your kube cluster

--- a/kustomize_envs/dev/README.md
+++ b/kustomize_envs/dev/README.md
@@ -7,7 +7,6 @@ This doc describes how to use `skaffold` to run a detect-secrets-stream instance
 ### provision ahead of time
 
 - github-app:
-  - Named `detect-secrets-admin-tool-test`
   - `kustomize_envs/dev/secret_manual/app.key` stores the private key for this test Github App
   - `APP_ID` in `kustomize_envs/dev/secret_manual/env.txt` stores the Github App ID
 - a kafka queue named `diff-scan`

--- a/kustomize_envs/dev/README.md
+++ b/kustomize_envs/dev/README.md
@@ -4,15 +4,14 @@ This doc describes how to use `skaffold` to run a detect-secrets-stream instance
 
 ## Dependencies
 
-### provision ahead of time (already done)
+### provision ahead of time
 
-- github-app: [detect-secrets-admin-tool-test](https://github.ibm.com/github-apps/detect-secrets-admin-tool-test)
+- github-app:
+  - Named `detect-secrets-admin-tool-test`
   - `kustomize_envs/dev/secret_manual/app.key` stores the private key for this test Github App
   - `APP_ID` in `kustomize_envs/dev/secret_manual/env.txt` stores the Github App ID
 - a kafka queue named `diff-scan`
   - You can request a free kafka instance in your own IBM Cloud account. Service link: https://cloud.ibm.com/catalog/services/event-streams. Once created, generate a queue named `diff-scan` in the kafka instance. **TODO** parameterize queue name
-  - The one stored `kustomize_envs/dev/secret_manual/kafka.conf` is under @xianjun's account. Multiple people sharing the same queue can cause confusion when ingesting token.
-
 ### ondemand provision
 
 The resource below would be automatically provisioned when you run skaffold

--- a/kustomize_envs/dev/README.md
+++ b/kustomize_envs/dev/README.md
@@ -24,7 +24,7 @@ The resource below would be automatically provisioned when you run skaffold
 
 The steps below would deploy a test instance of detect-secrets-stream in a kube cluster you named. We are using [kind](https://kind.sigs.k8s.io/) to create a local cluster in the example below.
 
-You can also use other kube clusters. To install kind, run `brew install kind`
+To install kind, run `brew install kind`.
 
 ```shell
 # create a kube cluster, we are using kind

--- a/kustomize_envs/dev/README.md
+++ b/kustomize_envs/dev/README.md
@@ -34,9 +34,8 @@ kubectl config current-context # make sure you are on the kind cluster
 # create dev namespace
 kubectl create ns dev
 
-# generate local secrets
-# you can follow the guide in ../README#local-dev-secrets to set up your secrets
-# re-running the gen-secret script will not overwrite non-empty files
+# generate local secret files
+# refer to the Local Dev Secrets guide in the root project README to set up manually-entered secrets
 kustomize_envs/dev/gen-secret.sh
 
 # build image and deploy to dev cluster. "skaffold dev" would tail on log after image been deployed. In the meanwhile, you can use tools like k9s to monitor the status in your kube cluster

--- a/kustomize_envs/dev/kustomization.yaml
+++ b/kustomize_envs/dev/kustomization.yaml
@@ -90,7 +90,7 @@ secretGenerator:
   type: Opaque
 - name: gd-db-conf
   files:
-  - gd_db.conf=secret_manual/gd_db.conf
+  - gd_db.conf=secret_generated/gd_db.conf
   type: Opaque
 - name: gd-dc-secret
   files:

--- a/kustomize_envs/dev/kustomization.yaml
+++ b/kustomize_envs/dev/kustomization.yaml
@@ -111,4 +111,5 @@ secretGenerator:
   - ghe_revocation_token=secret_manual/ghe_revocation.token # manual
   - iam_conf=secret_manual/iam.conf # manual
   - revoker_urls_conf=secret_manual/revoker_urls.conf # manual
+  - email_conf=secret_manual/email.conf # manual
   type: Opaque


### PR DESCRIPTION
**What does this PR do?**
- `kustomize_envs/dev/kustomization.yaml`: points to correct `gd_db.conf` location to fix local kube env deploy
- `kustomize_envs/dev/README.md`: adds in comment about how to set up manual local dev secrets and removes ibm-specific references