### PR TITLE
Init GHE detector based on GHE endpoints

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -55,10 +55,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
-                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
+                "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee",
+                "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
             ],
-            "version": "==2020.12.5"
+            "version": "==2021.5.30"
         },
         "cffi": {
             "hashes": [
@@ -176,7 +176,7 @@
         },
         "detect-secrets": {
             "git": "https://github.com/ibm/detect-secrets.git",
-            "ref": "380bd3d2d56d6f1054dfd53a7b8a70c649559c2e"
+            "ref": "c279f78164a747ccf1ccd4ea78a065be7d5b1a97"
         },
         "flask": {
             "hashes": [
@@ -590,11 +590,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c",
-                "sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+                "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
+                "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.5"
+            "version": "==1.26.6"
         },
         "werkzeug": {
             "hashes": [
@@ -708,10 +708,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
-                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
+                "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee",
+                "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
             ],
-            "version": "==2020.12.5"
+            "version": "==2021.5.30"
         },
         "cfgv": {
             "hashes": [
@@ -789,10 +789,10 @@
         },
         "distlib": {
             "hashes": [
-                "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb",
-                "sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1"
+                "sha256:106fef6dc37dd8c0e2c0a60d3fca3e77460a48907f335fa28420463a6f799736",
+                "sha256:23e223426b28491b1ced97dc3bbe183027419dfc7982b4fa2f05d5f3ff10711c"
             ],
-            "version": "==0.3.1"
+            "version": "==0.3.2"
         },
         "filelock": {
             "hashes": [
@@ -818,11 +818,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:01ebbc7af37043806216c7550539210cde4f82451983eb8735a02b3b9d013e40",
-                "sha256:1560bb645b93d5c05c3535c72a4f4884133006423d02c692ac6862a45eb0d521"
+                "sha256:18d0c531ee3dbc112fa6181f34faa179de3f57ea57ae2899754f16a7e0ff6421",
+                "sha256:5b41f71471bc738e7b586308c3fca172f78940195cb3bf6734c1e66fdac49306"
             ],
             "markers": "python_full_version >= '3.6.1'",
-            "version": "==2.2.6"
+            "version": "==2.2.10"
         },
         "idna": {
             "hashes": [
@@ -1040,11 +1040,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c",
-                "sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+                "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
+                "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.5"
+            "version": "==1.26.6"
         },
         "virtualenv": {
             "hashes": [

--- a/detect_secrets_stream/validation/github.py
+++ b/detect_secrets_stream/validation/github.py
@@ -84,8 +84,8 @@ class GHEValidator(BaseValidator):
             json = {'hash': self.hash_token(secret)}
             response = requests.post(revocation_endpoint, headers=headers, params=params, json=json)
             response.raise_for_status()
-            jobs = response.json()['jobs']
-            return type(jobs) is list and len(jobs) > 0 and jobs[0]['triggered'] is True
+            jobsreslist = [v for v in response.json()['jobs'].values()]
+            return jobsreslist[0]['triggered'] is True
         except requests.exceptions.RequestException as e:
             self.logger.error(
                 f'Unexpected request exception while revoking token. Error {e}', exc_info=1,

--- a/detect_secrets_stream/validation/github.py
+++ b/detect_secrets_stream/validation/github.py
@@ -18,6 +18,7 @@ class GHEValidator(BaseValidator):
 
     def __init__(self):
         self.logger = logging.getLogger(__name__)
+        self.ghe_instance = ConfUtil.load_github_conf()['host']
 
     @staticmethod
     def secret_type_name():
@@ -25,7 +26,10 @@ class GHEValidator(BaseValidator):
 
     def validate(self, secret, other_factors=None):
         try:
-            result = GheDetector().verify(secret)
+            if self.ghe_instance:
+                result = GheDetector(ghe_instance=self.ghe_instance).verify(secret)
+            else:
+                result = GheDetector().verify(secret)
             if result == VerifiedResult.VERIFIED_TRUE:
                 return True
             elif result == VerifiedResult.VERIFIED_FALSE:

--- a/detect_secrets_stream/validation/github.py
+++ b/detect_secrets_stream/validation/github.py
@@ -84,7 +84,8 @@ class GHEValidator(BaseValidator):
             json = {'hash': self.hash_token(secret)}
             response = requests.post(revocation_endpoint, headers=headers, params=params, json=json)
             response.raise_for_status()
-            return response.json()['jobs']['Revoke Hashed GHE Token']['triggered'] is True
+            jobs = response.json()['jobs']
+            return type(jobs) is list and len(jobs) > 0 and jobs[0]['triggered'] is True
         except requests.exceptions.RequestException as e:
             self.logger.error(
                 f'Unexpected request exception while revoking token. Error {e}', exc_info=1,


### PR DESCRIPTION
After [supporting](https://github.com/IBM/detect-secrets/commit/61b4ac0cd7b0c5fb6cf31a001f38b2dde41b79a6) detecting token based on specific GHE instance, we also need to make sure verify step would also specify the GHE instance. Otherwise we might verifying GHE token against the wrong GHE instance.

Added another change to support Jenkins job with any name, instead of hard coded job name.