### PR TITLE
Remove Pyup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ TEST_ENV_VARS := GD_DC_KEY_FILENAME=$(GD_DC_KEY_FILENAME)                \
 
 COVERAGE := pipenv run coverage
 
-PIPENV_PYUP_API_KEY ?=
 # Only set if not defined
 VERSION ?= dev
 
@@ -135,7 +134,7 @@ ifdef TRAVIS
 endif
 	# ignore 41002: coverage <6.0b1 resolved (5.5 installed)! it's part of pytest-cov
 	# which does not have a version containing the fix.
-	env PIPENV_PYUP_API_KEY=$(PIPENV_PYUP_API_KEY) pipenv check --ignore 41002
+	pipenv check --ignore 41002
 	pre-commit run --all-files --show-diff-on-failure
 
 .PHONY: start-db_metrics


### PR DESCRIPTION
We have dependabot now. Once merged and verified, we can also remove the Pyup API from Travis env.