### PR TITLE
Use newer ingress

### DIFF
--- a/kustomize_envs/base/ingress/ingress.gd_ingest.yaml
+++ b/kustomize_envs/base/ingress/ingress.gd_ingest.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: gd-ingest
@@ -11,9 +11,12 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: gd-ingest
-              servicePort: 80
+              service:
+                name: gd-ingest
+                port:
+                  number: 80
   tls:
   - hosts:
     - gd-ingest.mycompany.com

--- a/kustomize_envs/base/ingress/ingress.gd_revoker.yaml
+++ b/kustomize_envs/base/ingress/ingress.gd_revoker.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: gd-revoker
@@ -11,9 +11,12 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: gd-revoker
-          servicePort: 80
+          service:
+            name: gd-revoker
+            port:
+              number: 80
   tls:
   - hosts:
     - gd-revoker.mycompany.com


### PR DESCRIPTION
The old ingress syntax was deprecated in kube 1.22 now. Start to use the new apiVersion.