### PR TITLE
Replace references to detect-secrets repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Detect Secrets Stream [![Build Status](https://travis-ci.com/IBM/detect-secrets-stream.svg?branch=main)](https://travis-ci.com/IBM/detect-secrets-stream.svg?branch=main)
+# Detect Secrets Stream
+
+[![Build Status](https://travis-ci.com/IBM/detect-secrets-stream.svg?branch=main)](https://travis-ci.com/IBM/detect-secrets-stream.svg?branch=main)
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Detect Secrets Stream ![Build Status](https://travis-ci.com/IBM/detect-secrets-stream.svg?branch=main)](https://travis-ci.com/IBM/detect-secrets-stream.svg?branch=main)
+# Detect Secrets Stream [![Build Status](https://travis-ci.com/IBM/detect-secrets-stream.svg?branch=main)](https://travis-ci.com/IBM/detect-secrets-stream.svg?branch=main)
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Detect Secrets Stream [![Build Status](https://travis-ci.com/IBM/detect-secrets-stream.svg?branch=main)](https://travis-ci.com/IBM/detect-secrets-stream.svg?branch=main)
+# Detect Secrets Stream ![Build Status](https://travis-ci.com/IBM/detect-secrets-stream.svg?branch=main)](https://travis-ci.com/IBM/detect-secrets-stream.svg?branch=main)
 
 ## Description
 

--- a/detect_secrets_stream/scan_worker/README.md
+++ b/detect_secrets_stream/scan_worker/README.md
@@ -1,4 +1,4 @@
 # scan-worker
-A Kubernetes worker that pulls from a Kafka queue and performs a whitewater-detect-secrets scan.
+A Kubernetes worker that pulls from a Kafka queue and performs a [detect-secrets](https://github.com/IBM/detect-secrets) scan.
 
 Adapted from [this Kubernetes tutorial](https://kubernetes.io/docs/tasks/job/fine-parallel-processing-work-queue/) and [this IBM Event Streams code sample](https://github.com/ibm-messaging/event-streams-samples/tree/master/kafka-python-console-sample).

--- a/detect_secrets_stream/scan_worker/test_data/diff_files/removed.diff
+++ b/detect_secrets_stream/scan_worker/test_data/diff_files/removed.diff
@@ -9,8 +9,8 @@ index 456100d..dc6b7e2 100644
 -# Remove the fake gd_db_tools that exists for testing until mono-repo is implemented
 -RUN rm -f ./gd_db_tools.py
 -
- # Copy /whitewater-detect-secrets from builder stage
- COPY --from=builder /whitewater-detect-secrets /whitewater-detect-secrets
+ # Copy /detect-secrets from builder stage
+ COPY --from=builder /detect-secrets /detect-secrets
 
 diff --git a/diffscanworker_test.py b/diffscanworker_test.py
 index 16bb25c..651dfcb 100644

--- a/docs/adding-a-new-detector.md
+++ b/docs/adding-a-new-detector.md
@@ -20,7 +20,7 @@ Adding a new type of detector to detect-secrets-suite is a multi-stage process. 
 
 For detailed instructions on developing a new secret detector, see:
 
-- [`IBM/detect-secrets` CONTRIBUTING.md - Process for Adding a New Secret Detector to whitewater-detect-secrets](https://github.com/IBM/detect-secrets/blob/master/CONTRIBUTING.md#process-for-adding-a-new-secret-detector-to-whitewater-detect-secrets)
+- [`IBM/detect-secrets` CONTRIBUTING.md - Process for Adding a New Secret Detector to detect-secrets](https://github.com/IBM/detect-secrets/blob/master/CONTRIBUTING.md#process-for-adding-a-new-secret-detector-to-detect-secrets)
 - [`IBM/detect-secrets-stream` CONTRIBUTING.md - Process for Supporting a New Secret Type in detect-secrets-stream](../CONTRIBUTING.md#process-for-supporting-a-new-secret-type-in-detect-secrets-stream)
 
 Please open one or more PRs using the instructions above.

--- a/kustomize_envs/dev/README.md
+++ b/kustomize_envs/dev/README.md
@@ -1,6 +1,6 @@
 # local end 2 end test
 
-This doc describes how to use `skaffold` to run a detect-secrets-stream instance in a local kube env and run some end 2 end test.
+This document describes how to use [`skaffold`](https://skaffold.dev/docs/references/cli/) to run a detect-secrets-stream instance in a local Kubernetes environment and run some end to end tests.
 
 ## Dependencies
 
@@ -10,11 +10,11 @@ This doc describes how to use `skaffold` to run a detect-secrets-stream instance
   - `kustomize_envs/dev/secret_manual/app.key` stores the private key for this test Github App
   - `APP_ID` in `kustomize_envs/dev/secret_manual/env.txt` stores the Github App ID
 - a kafka queue named `diff-scan`
-  - You can request a free kafka instance in your own IBM Cloud account. Service link: https://cloud.ibm.com/catalog/services/event-streams. Once created, generate a queue named `diff-scan` in the kafka instance. **TODO** parameterize queue name
+  - You can request a free Kafka instance in your own IBM Cloud account. The service can be found [here](https://cloud.ibm.com/catalog/services/event-streams). Once created, generate a queue named `diff-scan` in the kafka instance. **TODO** parameterize queue name
 
 ### ondemand provision
 
-The resource below would be automatically provisioned when you run skaffold
+The resources below will be automatically provisioned when you run [`skaffold`](https://skaffold.dev/docs/references/cli/):
 
 - postgres
 - vault
@@ -46,7 +46,7 @@ kind delete cluster
 
 ## Execute test
 
-The ingest script reads payload from `kustomize_envs/dev/test/ingest.payload.json`, you can edit that file to customize the payload such as which repo and which commit to ingest.
+The ingest script reads payloads from `kustomize_envs/dev/test/ingest.payload.json`; you can edit this file to customize the payload, such as which repo and which commit to ingest.
 
 ```shell
 # Ingest token by sending payload to ingest layer


### PR DESCRIPTION
The Detect Secrets developer tool repository is named `detect-secrets`, not `whitewater-detect-secrets`. This PR updates references to that repository within this project.