### PR TITLE
Update tagPolicy skaffold.yaml

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -7,7 +7,8 @@ build:
   local:
     useDockerCLI: true
   tagPolicy:
-    sha256: {}
+    envTemplate:
+      template: "{{.VERSION}}"
   artifacts:
   - image: icr.io/git-defenders/detect-secrets-stream
     context: .


### PR DESCRIPTION
Updated `tagPolicy:`

From:
```
tagPolicy:
    sha256: {}
```

To:
```
tagPolicy:
    envTemplate:
      template: "{{.VERSION}}"
```

so that the version tag within IBM-Cloud follows `ibm-cloud-secrets-manager-<VERSION>` as opposed to `latest`